### PR TITLE
[#8][Infrastructure] Setting CloudWatch for log monitoring. 

### DIFF
--- a/core/main.tf
+++ b/core/main.tf
@@ -8,6 +8,12 @@ terraform {
   }
 }
 
+module "cloudwatch" {
+  source = "../modules/cloudwatch"
+
+#  kms_key_id = module.secrets_manager.secret_cloudwatch_log_key_arn
+}
+
 module "secrets_manager" {
   source = "../modules/secrets_manager"
 

--- a/core/main.tf
+++ b/core/main.tf
@@ -11,7 +11,7 @@ terraform {
 module "cloudwatch" {
   source = "../modules/cloudwatch"
 
-#  kms_key_id = module.secrets_manager.secret_cloudwatch_log_key_arn
+  kms_key_id = module.secrets_manager.secret_cloudwatch_log_key_arn
 }
 
 module "secrets_manager" {

--- a/modules/cloudwatch/locals.tf
+++ b/modules/cloudwatch/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  # The namespace for the CloudWatch log group
+  namespace = "devops-ic-cloudwatch"
+
+  # Log retention in days
+  retention_in_days = 30
+}

--- a/modules/cloudwatch/locals.tf
+++ b/modules/cloudwatch/locals.tf
@@ -3,5 +3,5 @@ locals {
   namespace = "devops-ic-cloudwatch"
 
   # Log retention in days
-  retention_in_days = 30
+  retention_in_days = 400
 }

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "this" {
   name              = local.namespace
   retention_in_days = local.retention_in_days
-#  kms_key_id        = var.kms_key_id
+  kms_key_id        = var.kms_key_id
 }

--- a/modules/cloudwatch/main.tf
+++ b/modules/cloudwatch/main.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = local.namespace
+  retention_in_days = local.retention_in_days
+#  kms_key_id        = var.kms_key_id
+}

--- a/modules/cloudwatch/outputs.tf
+++ b/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "aws_cloudwatch_log_group_name" {
+  description = "CloudWatch log group name"
+  value       = aws_cloudwatch_log_group.this.name
+}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -1,0 +1,4 @@
+#  variable "kms_key_id" {
+#  description = "The KMS key ID to use for encryption"
+#  type        = string
+#}

--- a/modules/cloudwatch/variables.tf
+++ b/modules/cloudwatch/variables.tf
@@ -1,4 +1,4 @@
-#  variable "kms_key_id" {
-#  description = "The KMS key ID to use for encryption"
-#  type        = string
-#}
+variable "kms_key_id" {
+  description = "The KMS key ID to use for encryption"
+  type        = string
+}

--- a/modules/secrets_manager/locals.tf
+++ b/modules/secrets_manager/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Description of the KMS key
-  description = "KMS key for ${local.namespace}-service"
+  description = "KMS key for CloudWatch service"
 
   # The namespace for the KMS
   namespace = "devops-ic-kms"

--- a/modules/secrets_manager/locals.tf
+++ b/modules/secrets_manager/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Description of the KMS key
-  description = "KMS key for CloudWatch service"
+  description = "KMS key for ${local.namespace} service"
 
   # The namespace for the KMS
   namespace = "devops-ic-kms"

--- a/modules/secrets_manager/main.tf
+++ b/modules/secrets_manager/main.tf
@@ -1,14 +1,14 @@
-resource "aws_kms_key" "service_key" {
+resource "aws_kms_key" "secret_cloudwatch_log_key_arn" {
   description         = local.description
   enable_key_rotation = local.enable_key_rotation
 }
 
-resource "aws_kms_key_policy" "service_key_policy" {
-  key_id = aws_kms_key.service_key.id
+resource "aws_kms_key_policy" "secret_cloudwatch_log_key_arn_policy" {
+  key_id = aws_kms_key.secret_cloudwatch_log_key_arn.id
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Id      = "service_key_policy"
+    Id      = "secret_cloudwatch_log_key_arn_policy"
     Statement = [
       {
         Action = "kms:*"
@@ -30,7 +30,7 @@ resource "aws_secretsmanager_secret" "service_secrets" {
 
   name                    = "${local.namespace}/${lower(each.key)}"
   description             = "Secret `${lower(each.key)}` for ${local.namespace}"
-  kms_key_id              = aws_kms_key.service_key.arn
+  kms_key_id              = aws_kms_key.secret_cloudwatch_log_key_arn.arn
   recovery_window_in_days = 0
 
   tags = {

--- a/modules/secrets_manager/outputs.tf
+++ b/modules/secrets_manager/outputs.tf
@@ -7,3 +7,8 @@ output "secret_arns" {
   description = "The secrets ARNs for Task Definition"
   value       = local.secret_arns
 }
+
+output "secret_cloudwatch_log_key_arn" {
+  description = "The key to use for logs encryption"
+  value       = aws_kms_key.secret_cloudwatch_log_key_arn.arn
+}


### PR DESCRIPTION
- Close #8

## What happened 👀

Configure Amazon CloudWatch to effectively monitor logs generated by our applications.
- [x] Setting up Amazon CloudWatch without KMS
- [x] Integrate with KMS

## Insight 📝

`Checkov` raised that we need to ensure CloudWatch log groups retains logs for at least 1 year, therefore we shouldn't store the logs for only 2 weeks or a month.

```
Check: CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
	FAILED for resource: module.cloudwatch.aws_cloudwatch_log_group.this
Error: 	File: /modules/cloudwatch/main.tf:1-5
```

## Proof Of Work 📹

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
  - destroy

Terraform will perform the following actions:

  # module.cloudwatch.aws_cloudwatch_log_group.this will be created
  + resource "aws_cloudwatch_log_group" "this" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + kms_key_id        = (known after apply)
      + name              = "devops-ic-cloudwatch"
      + name_prefix       = (known after apply)
      + retention_in_days = 30
      + skip_destroy      = false
      + tags_all          = {
          + "Environment" = "staging"
          + "Owner"       = "sanghuynh20000"
        }
    }

  # module.secrets_manager.aws_kms_key.secret_cloudwatch_log_key_arn will be created
  + resource "aws_kms_key" "secret_cloudwatch_log_key_arn" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + description                        = "KMS key for CloudWatch service"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = {
          + "Environment" = "staging"
          + "Owner"       = "sanghuynh20000"
        }
    }

  # module.secrets_manager.aws_kms_key.service_key will be destroyed
  - resource "aws_kms_key" "service_key" {
      - arn                                = "arn:aws:kms:ap-southeast-1:038674931392:key/ff716a8c-3522-4214-9222-fcf63ab961a6" -> null
      - bypass_policy_lockout_safety_check = false -> null
      - customer_master_key_spec           = "SYMMETRIC_DEFAULT" -> null
      - description                        = "KMS key for devops-ic-kms-service" -> null
      - enable_key_rotation                = true -> null
      - id                                 = "ff716a8c-3522-4214-9222-fcf63ab961a6" -> null
      - is_enabled                         = true -> null
      - key_id                             = "ff716a8c-3522-4214-9222-fcf63ab961a6" -> null
      - key_usage                          = "ENCRYPT_DECRYPT" -> null
      - multi_region                       = false -> null
      - policy                             = jsonencode(
            {
              - Id        = "service_key_policy"
              - Statement = [
                  - {
                      - Action    = "kms:*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "*"
                        }
                      - Resource  = "*"
                      - Sid       = "Enable IAM User Permissions"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - tags                               = {} -> null
      - tags_all                           = {
          - "Environment" = "staging"
          - "Owner"       = "sanghuynh20000"
        } -> null
    }

  # module.secrets_manager.aws_kms_key_policy.secret_cloudwatch_log_key_arn_policy will be created
  + resource "aws_kms_key_policy" "secret_cloudwatch_log_key_arn_policy" {
      + bypass_policy_lockout_safety_check = false
      + id                                 = (known after apply)
      + key_id                             = (known after apply)
      + policy                             = jsonencode(
            {
              + Id        = "secret_cloudwatch_log_key_arn_policy"
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable IAM User Permissions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # module.secrets_manager.aws_kms_key_policy.service_key_policy will be destroyed
  - resource "aws_kms_key_policy" "service_key_policy" {
      - bypass_policy_lockout_safety_check = false -> null
      - id                                 = "ff716a8c-3522-4214-9222-fcf63ab961a6" -> null
      - key_id                             = "ff716a8c-3522-4214-9222-fcf63ab961a6" -> null
      - policy                             = jsonencode(
            {
              - Id        = "service_key_policy"
              - Statement = [
                  - {
                      - Action    = "kms:*"
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "*"
                        }
                      - Resource  = "*"
                      - Sid       = "Enable IAM User Permissions"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
    }

  # module.secrets_manager.aws_secretsmanager_secret.service_secrets["secret_key_base"] will be updated in-place
  ~ resource "aws_secretsmanager_secret" "service_secrets" {
        id                             = "arn:aws:secretsmanager:ap-southeast-1:038674931392:secret:devops-ic-kms/secret_key_base-oZEztE"
      ~ kms_key_id                     = "arn:aws:kms:ap-southeast-1:038674931392:key/ff716a8c-3522-4214-9222-fcf63ab961a6" -> (known after apply)
        name                           = "devops-ic-kms/secret_key_base"
        tags                           = {
            "Name" = "devops-ic-kms-secrets-manager"
        }
        # (5 unchanged attributes hidden)
    }

Plan: 3 to add, 1 to change, 2 to destroy.

```
