### PR TITLE
[#5][Infrastructure] Setting up AWS ECS Fargate for container orchestration.

### DIFF
--- a/core/assets/ecs_configs/production.json
+++ b/core/assets/ecs_configs/production.json
@@ -1,0 +1,9 @@
+{
+  "task_desired_count": 3,
+  "web_container_cpu": 256,
+  "web_container_memory": 512,
+  "deployment_maximum_percent": 200,
+  "deployment_minimum_healthy_percent": 50,
+  "max_capacity": 10,
+  "max_cpu_threshold": 80
+}

--- a/core/assets/ecs_configs/staging.json
+++ b/core/assets/ecs_configs/staging.json
@@ -1,0 +1,9 @@
+{
+  "task_desired_count": 3,
+  "web_container_cpu": 256,
+  "web_container_memory": 512,
+  "deployment_maximum_percent": 200,
+  "deployment_minimum_healthy_percent": 50,
+  "max_capacity": 10,
+  "max_cpu_threshold": 80
+}

--- a/core/assets/environment_variables/production.json
+++ b/core/assets/environment_variables/production.json
@@ -1,0 +1,4 @@
+{
+  "AVAILABLE_LOCALES": "en",
+  "DEFAULT_LOCALE": "en"
+}

--- a/core/assets/environment_variables/staging.json
+++ b/core/assets/environment_variables/staging.json
@@ -1,0 +1,4 @@
+{
+  "AVAILABLE_LOCALES": "en",
+  "DEFAULT_LOCALE": "en"
+}

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -25,4 +25,13 @@ locals {
     staging    = jsondecode(file("assets/ecs_configs/staging.json"))
     production = jsondecode(file("assets/ecs_configs/production.json"))
   }
+
+  # ENV variables for the current environment
+  current_environment_variables = local.environment_variables[var.environment]
+
+  # ENV variables for each environment
+  environment_variables = {
+    staging    = [for k, v in jsondecode(file("assets/environment_variables/staging.json")) : { name = k, value = v }]
+    production = [for k, v in jsondecode(file("assets/environment_variables/production.json")) : { name = k, value = v }]
+  }
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -16,4 +16,13 @@ locals {
 
   # The health check path of the Application
   health_check_path = "/health"
+
+  # The ECS configuration for the current environment
+  current_ecs_config = local.ecs_config[var.environment]
+
+  # ECS configurations for each environment
+  ecs_config = {
+    staging    = jsondecode(file("assets/ecs_configs/staging.json"))
+    production = jsondecode(file("assets/ecs_configs/production.json"))
+  }
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -5,6 +5,9 @@ locals {
   # The owner of the infrastructure, used to tag the resources, e.g. `acme-web`
   owner = "sanghuynh20000"
 
+  # The repository name of the ECR to retrieve the image from
+  ecr_repo_name = "devops-ic-ecr"
+
   # AWS region
   region = "ap-southeast-1"
 

--- a/core/main.tf
+++ b/core/main.tf
@@ -56,7 +56,6 @@ module "ecs" {
   ecr_repo_name                 = local.ecr_repo_name
   health_check_path             = local.health_check_path
   subnets                       = module.vpc.private_subnet_ids
-  app_host                      = module.alb.alb_dns_name
   security_groups               = module.security_group.ecs_security_group_ids
   alb_target_group_arn          = module.alb.alb_target_group_arn
   aws_cloudwatch_log_group_name = module.cloudwatch.aws_cloudwatch_log_group_name

--- a/core/main.tf
+++ b/core/main.tf
@@ -67,6 +67,7 @@ module "ecs" {
   max_capacity                       = local.current_ecs_config.max_capacity
   max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
 
-  secrets_variables = module.secrets_manager.secrets_variables
-  secret_arns       = module.secrets_manager.secret_arns
+  environment_variables = local.current_environment_variables
+  secrets_variables     = module.secrets_manager.secrets_variables
+  secret_arns           = module.secrets_manager.secret_arns
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -51,14 +51,21 @@ module "secrets_manager" {
 module "ecs" {
   source = "../modules/ecs"
 
-  region                        = local.region
-  app_port                      = local.app_port
-  ecr_repo_name                 = local.ecr_repo_name
-  health_check_path             = local.health_check_path
-  subnets                       = module.vpc.private_subnet_ids
-  security_groups               = module.security_group.ecs_security_group_ids
-  alb_target_group_arn          = module.alb.alb_target_group_arn
-  aws_cloudwatch_log_group_name = module.cloudwatch.aws_cloudwatch_log_group_name
+  region                             = local.region
+  app_port                           = local.app_port
+  ecr_repo_name                      = local.ecr_repo_name
+  health_check_path                  = local.health_check_path
+  subnets                            = module.vpc.private_subnet_ids
+  security_groups                    = module.security_group.ecs_security_group_ids
+  alb_target_group_arn               = module.alb.alb_target_group_arn
+  aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
+  deployment_maximum_percent         = local.current_ecs_config.deployment_maximum_percent
+  deployment_minimum_healthy_percent = local.current_ecs_config.deployment_minimum_healthy_percent
+  web_container_cpu                  = local.current_ecs_config.web_container_cpu
+  web_container_memory               = local.current_ecs_config.web_container_memory
+  task_desired_count                 = local.current_ecs_config.task_desired_count
+  max_capacity                       = local.current_ecs_config.max_capacity
+  max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
 
   secrets_variables = module.secrets_manager.secrets_variables
   secret_arns       = module.secrets_manager.secret_arns

--- a/core/main.tf
+++ b/core/main.tf
@@ -51,22 +51,15 @@ module "secrets_manager" {
 module "ecs" {
   source = "../modules/ecs"
 
-  region                             = local.region
-  app_port                           = local.app_port
-  ecr_repo_name                      = local.ecr_repo_name
-  health_check_path                  = local.health_check_path
-  subnets                            = module.vpc.private_subnet_ids
-  app_host                           = module.alb.alb_dns_name
-  security_groups                    = module.security_group.ecs_security_group_ids
-  alb_target_group_arn               = module.alb.alb_target_group_arn
-  aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
-  deployment_maximum_percent         = var.ecs.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.ecs.deployment_minimum_healthy_percent
-  web_container_cpu                  = var.ecs.web_container_cpu
-  web_container_memory               = var.ecs.web_container_memory
-  desired_count                      = var.ecs.task_desired_count
-  max_capacity                       = var.ecs.max_capacity
-  max_cpu_threshold                  = var.ecs.max_cpu_threshold
+  region                        = local.region
+  app_port                      = local.app_port
+  ecr_repo_name                 = local.ecr_repo_name
+  health_check_path             = local.health_check_path
+  subnets                       = module.vpc.private_subnet_ids
+  app_host                      = module.alb.alb_dns_name
+  security_groups               = module.security_group.ecs_security_group_ids
+  alb_target_group_arn          = module.alb.alb_target_group_arn
+  aws_cloudwatch_log_group_name = module.cloudwatch.aws_cloudwatch_log_group_name
 
   secrets_variables = module.secrets_manager.secrets_variables
   secret_arns       = module.secrets_manager.secret_arns

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -8,17 +8,3 @@ variable "secret_key_base" {
   description = "The secret key base for the application"
   type        = string
 }
-
-variable "ecs" {
-  description = "ECS input variables"
-
-  type = object({
-    task_desired_count                 = number
-    web_container_cpu                  = number
-    web_container_memory               = number
-    deployment_maximum_percent         = number
-    deployment_minimum_healthy_percent = number
-    max_capacity                       = number
-    max_cpu_threshold                  = number
-  })
-}

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -8,3 +8,17 @@ variable "secret_key_base" {
   description = "The secret key base for the application"
   type        = string
 }
+
+variable "ecs" {
+  description = "ECS input variables"
+
+  type = object({
+    task_desired_count                 = number
+    web_container_cpu                  = number
+    web_container_memory               = number
+    deployment_maximum_percent         = number
+    deployment_minimum_healthy_percent = number
+    max_capacity                       = number
+    max_cpu_threshold                  = number
+  })
+}

--- a/modules/alb/locals.tf
+++ b/modules/alb/locals.tf
@@ -10,9 +10,9 @@ locals {
   application_target_type                 = "ip"
   application_target_deregistration_delay = 100
 
-  # health_check
+  # Health check timeout must be smaller than the interval
   health_check_timeout             = 20
-  health_check_interval            = 5
+  health_check_interval            = 30
   health_check_healthy_threshold   = 3
   health_check_unhealthy_threshold = 3
   health_check_protocol            = "HTTP"

--- a/modules/ecs/data.tf
+++ b/modules/ecs/data.tf
@@ -1,0 +1,21 @@
+data "aws_ecr_repository" "repo" {
+  name = var.ecr_repo_name
+}
+
+data "aws_ecs_task_definition" "task" {
+  task_definition = aws_ecs_task_definition.main.family
+}
+
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}

--- a/modules/ecs/data.tf
+++ b/modules/ecs/data.tf
@@ -3,7 +3,7 @@ data "aws_ecr_repository" "repo" {
 }
 
 data "aws_ecs_task_definition" "task" {
-  task_definition = aws_ecs_task_definition.main.family
+  task_definition = aws_ecs_task_definition.this.family
 }
 
 data "aws_iam_policy_document" "ecs_task_execution_role" {

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -2,7 +2,7 @@ locals {
   # The namespace for the ECS
   namespace = "devops-ic-ecs"
 
-  ecr_tag                            = "${local.namespace}-app"
+  ecr_tag = "${local.namespace}-app"
 
   # Environment variables from other variables
   environment_variables = toset([
@@ -19,7 +19,7 @@ locals {
     aws_ecr_tag                   = local.ecr_tag
     aws_cloudwatch_log_group_name = var.aws_cloudwatch_log_group_name
 
-    environment_variables = local.environment_variables
+    environment_variables = setunion(local.environment_variables, var.environment_variables)
     secrets_variables     = var.secrets_variables
   }
 

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -15,20 +15,16 @@ locals {
   environment_variables = toset([
     { name = "AWS_REGION", value = var.region },
     { name = "HEALTH_CHECK_PATH", value = var.health_check_path },
-    { name = "APP_HOST", value = var.app_host },
     { name = "APP_PORT", value = var.app_port }
   ])
 
   container_vars = {
-    namespace                          = local.namespace
-    region                             = var.region
-    app_host                           = var.app_host
-    app_port                           = var.app_port
-    deployment_maximum_percent         = local.deployment_maximum_percent
-    deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
-    aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url
-    aws_ecr_tag                        = local.ecr_tag
-    aws_cloudwatch_log_group_name      = var.aws_cloudwatch_log_group_name
+    namespace                     = local.namespace
+    region                        = var.region
+    app_port                      = var.app_port
+    aws_ecr_repository            = data.aws_ecr_repository.repo.repository_url
+    aws_ecr_tag                   = local.ecr_tag
+    aws_cloudwatch_log_group_name = var.aws_cloudwatch_log_group_name
 
     environment_variables = local.environment_variables
     secrets_variables     = var.secrets_variables

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -2,7 +2,14 @@ locals {
   # The namespace for the ECS
   namespace = "devops-ic-ecs"
 
-  ecr_tag = "${local.namespace}-app"
+  ecr_tag                            = "${local.namespace}-app"
+  task_desired_count                 = 3
+  web_container_cpu                  = 256
+  web_container_memory               = 512
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 50
+  max_capacity                       = 10
+  max_cpu_threshold                  = 80
 
   # Environment variables from other variables
   environment_variables = toset([
@@ -17,10 +24,10 @@ locals {
     region                             = var.region
     app_host                           = var.app_host
     app_port                           = var.app_port
-    web_container_cpu                  = var.web_container_cpu
-    web_container_memory               = var.web_container_memory
-    deployment_maximum_percent         = var.deployment_maximum_percent
-    deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+    web_container_cpu                  = local.web_container_cpu
+    web_container_memory               = local.web_container_memory
+    deployment_maximum_percent         = local.deployment_maximum_percent
+    deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
     aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url
     aws_ecr_tag                        = local.ecr_tag
     aws_cloudwatch_log_group_name      = var.aws_cloudwatch_log_group_name

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -45,7 +45,7 @@ locals {
           "kms:CreateGrant",
           "kms:DescribeKey",
         ],
-        Resource = "*"
+        Resource = "arn:aws:kms:*:*:key/*"
       }
     ]
   }

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -9,8 +9,7 @@ locals {
     { name = "AWS_REGION", value = var.region },
     { name = "HEALTH_CHECK_PATH", value = var.health_check_path },
     { name = "APP_HOST", value = var.app_host },
-    { name = "APP_PORT", value = var.app_port },
-    { name = "DATABASE_URL", value = "" },
+    { name = "APP_PORT", value = var.app_port }
   ])
 
   container_vars = {

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -3,13 +3,6 @@ locals {
   namespace = "devops-ic-ecs"
 
   ecr_tag                            = "${local.namespace}-app"
-  task_desired_count                 = 3
-  web_container_cpu                  = 256
-  web_container_memory               = 512
-  deployment_maximum_percent         = 200
-  deployment_minimum_healthy_percent = 50
-  max_capacity                       = 10
-  max_cpu_threshold                  = 80
 
   # Environment variables from other variables
   environment_variables = toset([

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -7,9 +7,9 @@ locals {
   # Environment variables from other variables
   environment_variables = toset([
     { name = "AWS_REGION", value = var.region },
-    { name = "HEALTH_PATH", value = var.health_check_path },
-    { name = "PHX_HOST", value = var.app_host },
-    { name = "PORT", value = var.app_port },
+    { name = "HEALTH_CHECK_PATH", value = var.health_check_path },
+    { name = "APP_HOST", value = var.app_host },
+    { name = "APP_PORT", value = var.app_port },
     { name = "DATABASE_URL", value = "" },
   ])
 

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -1,0 +1,65 @@
+locals {
+  # The namespace for the ECS
+  namespace = "devops-ic-ecs"
+
+  ecr_tag = "${local.namespace}-app"
+
+  # Environment variables from other variables
+  environment_variables = toset([
+    { name = "AWS_REGION", value = var.region },
+    { name = "HEALTH_PATH", value = var.health_check_path },
+    { name = "PHX_HOST", value = var.app_host },
+    { name = "PORT", value = var.app_port },
+    { name = "DATABASE_URL", value = "" },
+  ])
+
+  container_vars = {
+    namespace                          = local.namespace
+    region                             = var.region
+    app_host                           = var.app_host
+    app_port                           = var.app_port
+    web_container_cpu                  = var.web_container_cpu
+    web_container_memory               = var.web_container_memory
+    deployment_maximum_percent         = var.deployment_maximum_percent
+    deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+    aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url
+    aws_ecr_tag                        = local.ecr_tag
+    aws_cloudwatch_log_group_name      = var.aws_cloudwatch_log_group_name
+
+    environment_variables = local.environment_variables
+    secrets_variables     = var.secrets_variables
+  }
+
+  container_definitions = templatefile("${path.module}/service.json.tftpl", local.container_vars)
+
+  ecs_task_execution_kms_policy = {
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:CreateGrant",
+          "kms:DescribeKey",
+        ],
+        Resource = "*"
+      }
+    ]
+  }
+
+  ecs_task_execution_secrets_manager_policy = {
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = var.secret_arns
+      }
+    ]
+  }
+}

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -24,8 +24,6 @@ locals {
     region                             = var.region
     app_host                           = var.app_host
     app_port                           = var.app_port
-    web_container_cpu                  = local.web_container_cpu
-    web_container_memory               = local.web_container_memory
     deployment_maximum_percent         = local.deployment_maximum_percent
     deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
     aws_ecr_repository                 = data.aws_ecr_repository.repo.repository_url

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -46,8 +46,8 @@ resource "aws_ecs_cluster" "this" {
 
 resource "aws_ecs_task_definition" "this" {
   family                   = "${local.namespace}-service"
-  cpu                      = local.web_container_cpu
-  memory                   = local.web_container_memory
+  cpu                      = var.web_container_cpu
+  memory                   = var.web_container_memory
   network_mode             = "awsvpc"
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
@@ -59,9 +59,9 @@ resource "aws_ecs_service" "this" {
   name                               = "${local.namespace}-ecs-service"
   cluster                            = aws_ecs_cluster.this.id
   launch_type                        = "FARGATE"
-  deployment_maximum_percent         = local.deployment_maximum_percent
-  deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
-  desired_count                      = local.task_desired_count
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  desired_count                      = var.task_desired_count
   task_definition                    = "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.task.revision)}"
 
   deployment_circuit_breaker {
@@ -82,8 +82,8 @@ resource "aws_ecs_service" "this" {
 }
 
 resource "aws_appautoscaling_target" "this" {
-  max_capacity       = local.max_capacity
-  min_capacity       = local.task_desired_count
+  max_capacity       = var.max_capacity
+  min_capacity       = var.task_desired_count
   resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.this.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
@@ -97,7 +97,7 @@ resource "aws_appautoscaling_policy" "this" {
   service_namespace  = aws_appautoscaling_target.this.service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value = local.max_cpu_threshold
+    target_value = var.max_cpu_threshold
 
     scale_in_cooldown  = 300
     scale_out_cooldown = 300

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -46,8 +46,8 @@ resource "aws_ecs_cluster" "this" {
 
 resource "aws_ecs_task_definition" "this" {
   family                   = "${local.namespace}-service"
-  cpu                      = var.web_container_cpu
-  memory                   = var.web_container_memory
+  cpu                      = local.web_container_cpu
+  memory                   = local.web_container_memory
   network_mode             = "awsvpc"
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
@@ -59,9 +59,9 @@ resource "aws_ecs_service" "this" {
   name                               = "${local.namespace}-ecs-service"
   cluster                            = aws_ecs_cluster.this.id
   launch_type                        = "FARGATE"
-  deployment_maximum_percent         = var.deployment_maximum_percent
-  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  desired_count                      = var.desired_count
+  deployment_maximum_percent         = local.deployment_maximum_percent
+  deployment_minimum_healthy_percent = local.deployment_minimum_healthy_percent
+  desired_count                      = local.task_desired_count
   task_definition                    = "${aws_ecs_task_definition.this.family}:${max(aws_ecs_task_definition.this.revision, data.aws_ecs_task_definition.task.revision)}"
 
   deployment_circuit_breaker {
@@ -82,8 +82,8 @@ resource "aws_ecs_service" "this" {
 }
 
 resource "aws_appautoscaling_target" "this" {
-  max_capacity       = var.max_capacity
-  min_capacity       = var.desired_count
+  max_capacity       = local.max_capacity
+  min_capacity       = local.task_desired_count
   resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.this.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   service_namespace  = "ecs"
@@ -97,7 +97,7 @@ resource "aws_appautoscaling_policy" "this" {
   service_namespace  = aws_appautoscaling_target.this.service_namespace
 
   target_tracking_scaling_policy_configuration {
-    target_value = var.max_cpu_threshold
+    target_value = local.max_cpu_threshold
 
     scale_in_cooldown  = 300
     scale_out_cooldown = 300

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,0 +1,109 @@
+
+# Task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${local.namespace}-ecs-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards
+resource "aws_iam_policy" "ecs_task_execution_kms" {
+  policy = jsonencode(local.ecs_task_execution_kms_policy)
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_kms_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_kms.arn
+}
+
+resource "aws_iam_policy" "ecs_task_execution_secrets_manager" {
+  policy = jsonencode(local.ecs_task_execution_secrets_manager_policy)
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_secrets_manager_policy" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_task_execution_secrets_manager.arn
+}
+
+# Task role
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${local.namespace}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "${local.namespace}-ecs-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = "${local.namespace}-service"
+  cpu                      = var.web_container_cpu
+  memory                   = var.web_container_memory
+  network_mode             = "awsvpc"
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+  execution_role_arn       = aws_iam_role.ecs_task_execution_role.arn
+  container_definitions    = local.container_definitions
+  requires_compatibilities = ["FARGATE"]
+}
+
+resource "aws_ecs_service" "main" {
+  name                               = "${local.namespace}-ecs-service"
+  cluster                            = aws_ecs_cluster.main.id
+  launch_type                        = "FARGATE"
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  desired_count                      = var.desired_count
+  task_definition                    = "${aws_ecs_task_definition.main.family}:${max(aws_ecs_task_definition.main.revision, data.aws_ecs_task_definition.task.revision)}"
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    subnets         = var.subnets
+    security_groups = var.security_groups
+  }
+
+  load_balancer {
+    target_group_arn = var.alb_target_group_arn
+    container_port   = var.app_port
+    container_name   = local.namespace
+  }
+}
+
+resource "aws_appautoscaling_target" "main" {
+  max_capacity       = var.max_capacity
+  min_capacity       = var.desired_count
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "main" {
+  name               = "${local.namespace}-autoscaling-policy"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    target_value = var.max_cpu_threshold
+
+    scale_in_cooldown  = 300
+    scale_out_cooldown = 300
+
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+  }
+}

--- a/modules/ecs/service.json.tftpl
+++ b/modules/ecs/service.json.tftpl
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "${namespace}",
+    "image": "${aws_ecr_repository}:${aws_ecr_tag}",
+    "essential": true,
+    "memory": ${web_container_memory},
+    "cpu": ${web_container_cpu},
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port},
+        "protocol": "tcp"
+      }
+    ],
+    "environment": ${jsonencode(environment_variables)},
+    "secrets": ${jsonencode(secrets_variables)},
+    "ulimits": [
+      {
+        "name": "nofile",
+        "softLimit": 65536,
+        "hardLimit": 65536
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "${region}",
+        "awslogs-stream-prefix": "${namespace}-service",
+        "awslogs-group": "${aws_cloudwatch_log_group_name}"
+      }
+    }
+  }
+]

--- a/modules/ecs/service.json.tftpl
+++ b/modules/ecs/service.json.tftpl
@@ -3,8 +3,6 @@
     "name": "${namespace}",
     "image": "${aws_ecr_repository}:${aws_ecr_tag}",
     "essential": true,
-    "memory": ${web_container_memory},
-    "cpu": ${web_container_cpu},
     "portMappings": [
       {
         "containerPort": ${app_port},

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -3,11 +3,6 @@ variable "region" {
   type        = string
 }
 
-variable "app_host" {
-  description = "Application host name"
-  type        = string
-}
-
 variable "app_port" {
   description = "Application running port"
   type        = number

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,0 +1,88 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "app_host" {
+  description = "Application host name"
+  type        = string
+}
+
+variable "app_port" {
+  description = "Application running port"
+  type        = number
+}
+
+variable "ecr_repo_name" {
+  description = "ECR repo name"
+  type        = string
+}
+
+variable "subnets" {
+  description = "Subnet where ECS placed"
+  type        = list(string)
+}
+
+variable "security_groups" {
+  description = "One or more VPC security groups associated with ECS cluster"
+  type        = list(string)
+}
+
+variable "alb_target_group_arn" {
+  description = "ALB target group ARN"
+}
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "web_container_cpu" {
+  description = "ECS web container CPU"
+  type        = number
+}
+
+variable "web_container_memory" {
+  description = "ECS web container memory"
+  type        = number
+}
+
+variable "secrets_variables" {
+  description = "List of [{name = \"\", valueFrom = \"\"}] pairs of secret variables"
+  type        = list(any)
+}
+
+variable "secret_arns" {
+  description = "The secrets ARNs for Task Definition"
+  type        = list(string)
+}
+
+variable "desired_count" {
+  description = "ECS task definition instance number"
+  type        = number
+}
+
+variable "health_check_path" {
+  description = "Application health check path"
+  type        = string
+}
+
+variable "aws_cloudwatch_log_group_name" {
+  description = "AWS CloudWatch Log Group name"
+  type        = string
+}
+
+variable "max_capacity" {
+  description = "ECS max number of instances to run"
+  type        = number
+}
+
+variable "max_cpu_threshold" {
+  description = "Threshold for CPU load where to start autoscaling"
+  type        = number
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -82,3 +82,12 @@ variable "max_cpu_threshold" {
   description = "Threshold for CPU load where to start autoscaling"
   type        = number
 }
+
+variable "environment_variables" {
+  description = "Environment variables for running container"
+
+  type = set(object({
+    name  = string
+    value = string
+  }))
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -47,3 +47,38 @@ variable "aws_cloudwatch_log_group_name" {
   description = "AWS CloudWatch Log Group name"
   type        = string
 }
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower limit of the number of running tasks running during deployment"
+  type        = number
+}
+
+variable "web_container_cpu" {
+  description = "ECS web container CPU"
+  type        = number
+}
+
+variable "web_container_memory" {
+  description = "ECS web container memory"
+  type        = number
+}
+
+variable "task_desired_count" {
+  description = "ECS task definition instance number"
+  type        = number
+}
+
+variable "max_capacity" {
+  description = "ECS max number of instances to run"
+  type        = number
+}
+
+variable "max_cpu_threshold" {
+  description = "Threshold for CPU load where to start autoscaling"
+  type        = number
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -32,25 +32,6 @@ variable "alb_target_group_arn" {
   description = "ALB target group ARN"
 }
 
-variable "deployment_maximum_percent" {
-  description = "Upper limit of the number of running tasks running during deployment"
-  type        = number
-}
-
-variable "deployment_minimum_healthy_percent" {
-  description = "Lower limit of the number of running tasks running during deployment"
-  type        = number
-}
-
-variable "web_container_cpu" {
-  description = "ECS web container CPU"
-  type        = number
-}
-
-variable "web_container_memory" {
-  description = "ECS web container memory"
-  type        = number
-}
 
 variable "secrets_variables" {
   description = "List of [{name = \"\", valueFrom = \"\"}] pairs of secret variables"
@@ -62,11 +43,6 @@ variable "secret_arns" {
   type        = list(string)
 }
 
-variable "desired_count" {
-  description = "ECS task definition instance number"
-  type        = number
-}
-
 variable "health_check_path" {
   description = "Application health check path"
   type        = string
@@ -75,14 +51,4 @@ variable "health_check_path" {
 variable "aws_cloudwatch_log_group_name" {
   description = "AWS CloudWatch Log Group name"
   type        = string
-}
-
-variable "max_capacity" {
-  description = "ECS max number of instances to run"
-  type        = number
-}
-
-variable "max_cpu_threshold" {
-  description = "Threshold for CPU load where to start autoscaling"
-  type        = number
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -47,8 +47,17 @@ resource "aws_s3_bucket" "alb_log" {
 }
 
 resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
+  bucket     = aws_s3_bucket.alb_log.id
+  acl        = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
+}
+
+# Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
   bucket = aws_s3_bucket.alb_log.id
-  acl    = "private"
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "alb_log" {

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -52,8 +52,8 @@ resource "aws_s3_bucket_acl" "alb_log_bucket_acl" {
   depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
 }
 
-# Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"
 resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  #checkov:skip=CKV2_AWS_65: The bucket does not allow ACLs"
   bucket = aws_s3_bucket.alb_log.id
   rule {
     object_ownership = "ObjectWriter"

--- a/modules/security_group/locals.tf
+++ b/modules/security_group/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  namespace                      = "devops-ic-sg"
   alb_security_group_name        = "devops-ic-alb-sg"
   alb_security_group_description = "Security group for the ALB"
 }

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -33,6 +33,7 @@ resource "aws_security_group_rule" "alb_egress" {
 }
 
 resource "aws_security_group" "ecs_fargate" {
+  #checkov:skip=CKV2_AWS_5: This security group will be used by an ECS Fargate task
   name        = "${local.namespace}-ecs-fargate"
   description = "ECS Fargate Security Group"
   vpc_id      = var.vpc_id

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -31,3 +31,44 @@ resource "aws_security_group_rule" "alb_egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "From ALB to app"
 }
+
+resource "aws_security_group" "ecs_fargate" {
+  name        = "${local.namespace}-ecs-fargate"
+  description = "ECS Fargate Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${local.namespace}-ecs-fargate"
+  }
+}
+
+resource "aws_security_group_rule" "ecs_fargate_ingress_alb" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.ecs_fargate.id
+  protocol                 = "tcp"
+  from_port                = var.app_port
+  to_port                  = var.app_port
+  source_security_group_id = aws_security_group.alb.id
+  description              = "From ALB to app"
+}
+
+resource "aws_security_group_rule" "ecs_fargate_ingress_private" {
+  type              = "ingress"
+  security_group_id = aws_security_group.ecs_fargate.id
+  protocol          = "-1"
+  from_port         = 1024
+  to_port           = 65535
+  cidr_blocks       = var.private_subnets_cidr_blocks
+  description       = "From internal VPC to app"
+}
+
+#tfsec:ignore:aws-ec2-no-public-egress-sgr
+resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
+  type              = "egress"
+  security_group_id = aws_security_group.ecs_fargate.id
+  protocol          = "-1"
+  from_port         = 0
+  to_port           = 0
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "From app to everywhere"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -2,3 +2,8 @@ output "alb_security_group_ids" {
   description = "Security group IDs for ALB"
   value       = [aws_security_group.alb.id]
 }
+
+output "ecs_security_group_ids" {
+  description = "Security group IDs for ECS Fargate"
+  value       = [aws_security_group.ecs_fargate.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -7,3 +7,8 @@ variable "app_port" {
   description = "Application running port"
   type        = number
 }
+
+variable "private_subnets_cidr_blocks" {
+  description = "Private subnet CIDR blocks"
+  type        = list(string)
+}


### PR DESCRIPTION
- Close #5

## What happened 👀

Setup the AWS Elastic Container Service cluster that hosts the Fargate container for our serverless architecture
- [x] Add ECS Cluster
- [x] Add Task Definition to define task that Fargate will provision
- [x] Add data to retrieve the ECR repository URL from the shared workspace

## Insight 📝

I was struggling when deciding which value we should use for `task CPU and Memory` and then ended up with an interesting conclusion, we can use either `vCPU` or per MB units for CPU. Which means:
- `1` vCPU ~ `1024`MB
- `0.5` vCPU ~ `512`MB

> [!NOTE]  
>  I disabled the `rule CKV2_AWS_5 from Checkov` to ensure that Security Groups are attached to another resource, since we're using it for the ALB, not sure why it still raises it.

> [!NOTE]  
> Disable rule `CKV2_AWS_65` since AWS changes something in the ACL (bucket S3) and it says the default value is `ObjectWriter` and to use ACL you have to set ownership to `ObjectWriter` or `BucketOwnerPreferred`" (Enable mode). If you use `BucketOwnerEnforced (Disable),` Terraform (ACL resource) will break.

## Proof Of Work 📹

| Modules will be added                                                                                                         |
|-------------------------------------------------------------------------------------------------------------------------------|
| ![run-wWPbBEHYWoopBNkK _ Runs _ staging _ devops-ic _ Terraform Cloud](https://github.com/sanG-github/nimble-devops-ic-infrastructure/assets/63148598/3919568a-91f8-4a84-a6fc-38dad932358a) |

