### PR TITLE
[#6][Infrastructure] Set up RDS

### DIFF
--- a/core/locals.tf
+++ b/core/locals.tf
@@ -14,9 +14,6 @@ locals {
   # The application exposed port
   app_port = 3000
 
-  # The RDS port
-  rds_port = 5432
-
   # The health check path of the Application
   health_check_path = "/health"
 
@@ -42,17 +39,17 @@ locals {
 
   rds_config = {
     staging = {
-      rds_instance_type            = "db.t3.micro"
-      port                         = 5432
-      autoscaling_min_capacity     = 0
-      rds_autoscaling_max_capacity = 3
+      instance_type            = "db.t3.micro"
+      port                     = 5432
+      autoscaling_min_capacity = 0
+      autoscaling_max_capacity = 3
     }
 
     production = {
-      rds_instance_type            = "db.t3.micro"
-      port                         = 5432
-      autoscaling_min_capacity     = 1
-      rds_autoscaling_max_capacity = 3
+      instance_type            = "db.t3.micro"
+      port                     = 5432
+      autoscaling_min_capacity = 1
+      autoscaling_max_capacity = 3
     }
   }
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -37,4 +37,22 @@ locals {
     staging    = [for k, v in jsondecode(file("assets/environment_variables/staging.json")) : { name = k, value = v }]
     production = [for k, v in jsondecode(file("assets/environment_variables/production.json")) : { name = k, value = v }]
   }
+
+  current_rds_config = local.rds_config[var.environment]
+
+  rds_config = {
+    staging = {
+      rds_instance_type            = "db.t3.micro"
+      port                         = 5432
+      autoscaling_min_capacity     = 0
+      rds_autoscaling_max_capacity = 3
+    }
+
+    production = {
+      rds_instance_type            = "db.t3.micro"
+      port                         = 5432
+      autoscaling_min_capacity     = 1
+      rds_autoscaling_max_capacity = 3
+    }
+  }
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -14,6 +14,9 @@ locals {
   # The application exposed port
   app_port = 3000
 
+  # The RDS port
+  rds_port = 5432
+
   # The health check path of the Application
   health_check_path = "/health"
 

--- a/core/main.tf
+++ b/core/main.tf
@@ -81,12 +81,12 @@ module "rds" {
   vpc_id                 = module.vpc.vpc_id
   subnet_ids             = module.vpc.private_subnet_ids
 
-  instance_type = var.rds_instance_type
   database_name = var.environment
   username      = var.rds_username
   password      = var.rds_password
-  port          = local.rds_port
 
-  autoscaling_min_capacity = var.rds_autoscaling_min_capacity
-  autoscaling_max_capacity = var.rds_autoscaling_max_capacity
+  instance_type            = local.current_rds_config.instance_type
+  port                     = local.current_rds_config.port
+  autoscaling_min_capacity = local.current_rds_config.autoscaling_min_capacity
+  autoscaling_max_capacity = local.current_rds_config.autoscaling_max_capacity
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -21,7 +21,7 @@ module "security_group" {
 
   vpc_id                      = module.vpc.vpc_id
   app_port                    = local.app_port
-  rds_port                    = local.rds_port
+  rds_port                    = local.current_rds_config.port
   private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
 }
 

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -9,12 +9,6 @@ variable "secret_key_base" {
   type        = string
 }
 
-variable "rds_instance_type" {
-  description = "RDS instance type"
-  type        = string
-  default     = "db.t3.micro"
-}
-
 variable "rds_username" {
   description = "RDS username"
   type        = string
@@ -23,16 +17,4 @@ variable "rds_username" {
 variable "rds_password" {
   description = "RDS password"
   type        = string
-}
-
-variable "rds_autoscaling_min_capacity" {
-  description = "Minimum number of RDS read replicas when autoscaling is enabled"
-  type        = number
-  default     = 1
-}
-
-variable "rds_autoscaling_max_capacity" {
-  description = "Maximum number of RDS read replicas when autoscaling is enabled"
-  type        = number
-  default     = 5
 }

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -12,7 +12,7 @@ variable "secret_key_base" {
 variable "rds_instance_type" {
   description = "RDS instance type"
   type        = string
-  default     = "db.t2"
+  default     = "db.t3.micro"
 }
 
 variable "rds_username" {

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -12,7 +12,7 @@ variable "secret_key_base" {
 variable "rds_instance_type" {
   description = "RDS instance type"
   type        = string
-  default     = "db.t4g.medium"
+  default     = "db.t2"
 }
 
 variable "rds_username" {

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -7,14 +7,17 @@ variable "environment" {
 variable "secret_key_base" {
   description = "The secret key base for the application"
   type        = string
+  sensitive   = true
 }
 
 variable "rds_username" {
   description = "RDS username"
   type        = string
+  sensitive   = true
 }
 
 variable "rds_password" {
   description = "RDS password"
   type        = string
+  sensitive   = true
 }

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -8,3 +8,31 @@ variable "secret_key_base" {
   description = "The secret key base for the application"
   type        = string
 }
+
+variable "rds_instance_type" {
+  description = "RDS instance type"
+  type        = string
+  default     = "db.t4g.medium"
+}
+
+variable "rds_username" {
+  description = "RDS username"
+  type        = string
+}
+
+variable "rds_password" {
+  description = "RDS password"
+  type        = string
+}
+
+variable "rds_autoscaling_min_capacity" {
+  description = "Minimum number of RDS read replicas when autoscaling is enabled"
+  type        = number
+  default     = 1
+}
+
+variable "rds_autoscaling_max_capacity" {
+  description = "Maximum number of RDS read replicas when autoscaling is enabled"
+  type        = number
+  default     = 5
+}

--- a/modules/rds/data.tf
+++ b/modules/rds/data.tf
@@ -1,0 +1,1 @@
+data "aws_availability_zones" "available" {}

--- a/modules/rds/locals.tf
+++ b/modules/rds/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  namespace = "devops-ic-aurora-db"
+
+  engine         = "aurora-postgresql"
+  engine_version = "15.2"
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,4 +1,5 @@
 module "rds" {
+  #checkov:skip=CKV_TF_1: Use specific version instead of defining the commit hash
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "7.6.0"
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,7 +1,7 @@
 module "rds" {
   #checkov:skip=CKV_TF_1: Use specific version instead of defining the commit hash
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "7.6.0"
+  version = "8.5.0"
 
   name = local.namespace
 
@@ -23,7 +23,6 @@ module "rds" {
   autoscaling_max_capacity = var.autoscaling_max_capacity
 
   create_monitoring_role = var.create_monitoring_role
-  create_random_password = false
   create_security_group  = false
   storage_encrypted      = true
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,38 @@
+module "rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "7.6.0"
+
+  name = local.namespace
+
+  engine         = local.engine
+  engine_version = local.engine_version
+
+  availability_zones     = data.aws_availability_zones.available.names
+  vpc_id                 = var.vpc_id
+  subnets                = var.subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
+
+  instance_class = var.instance_type
+  instances = {
+    main = {}
+  }
+
+  autoscaling_enabled      = true
+  autoscaling_min_capacity = var.autoscaling_min_capacity
+  autoscaling_max_capacity = var.autoscaling_max_capacity
+
+  create_monitoring_role = var.create_monitoring_role
+  create_random_password = false
+  create_security_group  = false
+  storage_encrypted      = true
+
+  publicly_accessible = false
+
+  database_name       = var.database_name
+  master_username     = var.username
+  master_password     = var.password
+  port                = var.port
+  deletion_protection = false
+
+  enabled_cloudwatch_logs_exports = var.cloudwatch_logs_exports
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -32,7 +32,7 @@ module "rds" {
   master_username     = var.username
   master_password     = var.password
   port                = var.port
-  deletion_protection = false
+  deletion_protection = true
 
   enabled_cloudwatch_logs_exports = var.cloudwatch_logs_exports
 }

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "db_endpoint" {
+  value = module.rds.cluster_endpoint
+}
+
+output "db_url" {
+  value = "postgresql://${var.username}:${var.password}@${module.rds.cluster_endpoint}/${var.database_name}"
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,61 @@
+variable "database_name" {
+  description = "The DB name"
+  type        = string
+}
+
+variable "username" {
+  description = "The DB master username"
+  type        = string
+}
+
+variable "password" {
+  description = "The DB master password"
+  type        = string
+}
+
+variable "port" {
+  description = "The DB port"
+  type        = number
+}
+
+variable "instance_type" {
+  description = "The Aurora DB instance type"
+  type        = string
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of security group IDs to assign to the DB"
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs for DB subnet group"
+  type        = list(string)
+}
+
+variable "autoscaling_min_capacity" {
+  description = "Minimum number of read replicas when autoscaling is enabled"
+  default     = 1
+}
+
+variable "autoscaling_max_capacity" {
+  description = "Maximum number of read replicas when autoscaling is enabled"
+  default     = 3
+}
+
+variable "create_monitoring_role" {
+  description = "A flag whether to create the IAM role for monitoring"
+  type        = bool
+  default     = false
+}
+
+variable "cloudwatch_logs_exports" {
+  description = "A list of log types to export to CloudWatch"
+  type        = list(string)
+  default     = ["postgresql"]
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -75,6 +75,7 @@ resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
 }
 
 resource "aws_security_group" "rds" {
+  #checkov:skip=CKV2_AWS_5: This security group will be used by an RDS instance
   name        = "${local.namespace}-rds"
   description = "RDS Security Group"
   vpc_id      = var.vpc_id

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -73,3 +73,23 @@ resource "aws_security_group_rule" "ecs_fargate_egress_anywhere" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "From app to everywhere"
 }
+
+resource "aws_security_group" "rds" {
+  name        = "${local.namespace}-rds"
+  description = "RDS Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${local.namespace}-rds"
+  }
+}
+
+resource "aws_security_group_rule" "rds_ingress_app_fargate" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_fargate.id
+  description              = "From app to DB"
+}

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -7,3 +7,8 @@ output "ecs_security_group_ids" {
   description = "Security group IDs for ECS Fargate"
   value       = [aws_security_group.ecs_fargate.id]
 }
+
+output "rds_security_group_ids" {
+  description = "Security group IDs for Aurora"
+  value       = [aws_security_group.rds.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -12,3 +12,8 @@ variable "private_subnets_cidr_blocks" {
   description = "Private subnet CIDR blocks"
   type        = list(string)
 }
+
+variable "rds_port" {
+  description = "RDS port"
+  type        = number
+}


### PR DESCRIPTION
- Close #6

## What happened 👀

After setting up ECS and ALB, we're coming to the last step to set up the storage for our Application, RDS that is using the Aurora serverless service from AWS.

## Insight 📝

Disabled two wrong checks that we've already faced before with other resources
- `CKV_TF_1`: Use a specific version instead of defining the commit hash
- `CKV2_AWS_5`: This security group will be used by an RDS instance but it still raises a warning

## Proof Of Work 📹


| Modules will be added                                                                                                         |
|-------------------------------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/sanG-github/nimble-devops-ic-infrastructure/assets/63148598/053d55b0-caa4-4b90-b543-fb58518941cc) |

