### PR TITLE
[#17][Infrastructure] Setup EC2 server as Bastion

### DIFF
--- a/core/assets/environment_variables/production.json
+++ b/core/assets/environment_variables/production.json
@@ -1,4 +1,7 @@
 {
   "AVAILABLE_LOCALES": "en",
-  "DEFAULT_LOCALE": "en"
+  "DEFAULT_LOCALE": "en",
+  "FALLBACK_LOCALES": "en",
+  "MAILER_DEFAULT_HOST": "localhost",
+  "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/production.json
+++ b/core/assets/environment_variables/production.json
@@ -1,8 +1,4 @@
 {
-  "APP_PORT": "3000",
-  "AVAILABLE_LOCALES": "en",
-  "DEFAULT_LOCALE": "en",
-  "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
   "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/production.json
+++ b/core/assets/environment_variables/production.json
@@ -1,8 +1,8 @@
 {
+  "APP_PORT": "3000",
   "AVAILABLE_LOCALES": "en",
   "DEFAULT_LOCALE": "en",
   "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
-  "MAILER_DEFAULT_PORT": "80",
-  "APP_PORT": "3000"
+  "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/production.json
+++ b/core/assets/environment_variables/production.json
@@ -3,5 +3,6 @@
   "DEFAULT_LOCALE": "en",
   "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
-  "MAILER_DEFAULT_PORT": "80"
+  "MAILER_DEFAULT_PORT": "80",
+  "APP_PORT": "3000"
 }

--- a/core/assets/environment_variables/staging.json
+++ b/core/assets/environment_variables/staging.json
@@ -1,4 +1,7 @@
 {
   "AVAILABLE_LOCALES": "en",
-  "DEFAULT_LOCALE": "en"
+  "DEFAULT_LOCALE": "en",
+  "FALLBACK_LOCALES": "en",
+  "MAILER_DEFAULT_HOST": "localhost",
+  "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/staging.json
+++ b/core/assets/environment_variables/staging.json
@@ -1,8 +1,4 @@
 {
-  "APP_PORT": "3000",
-  "AVAILABLE_LOCALES": "en",
-  "DEFAULT_LOCALE": "en",
-  "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
   "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/staging.json
+++ b/core/assets/environment_variables/staging.json
@@ -1,8 +1,8 @@
 {
+  "APP_PORT": "3000",
   "AVAILABLE_LOCALES": "en",
   "DEFAULT_LOCALE": "en",
   "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
-  "MAILER_DEFAULT_PORT": "80",
-  "APP_PORT": "3000"
+  "MAILER_DEFAULT_PORT": "80"
 }

--- a/core/assets/environment_variables/staging.json
+++ b/core/assets/environment_variables/staging.json
@@ -3,5 +3,6 @@
   "DEFAULT_LOCALE": "en",
   "FALLBACK_LOCALES": "en",
   "MAILER_DEFAULT_HOST": "localhost",
-  "MAILER_DEFAULT_PORT": "80"
+  "MAILER_DEFAULT_PORT": "80",
+  "APP_PORT": "3000"
 }

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -39,14 +39,14 @@ locals {
 
   rds_config = {
     staging = {
-      instance_type            = "db.t3.micro"
+      instance_type            = "db.t3.medium"
       port                     = 5432
       autoscaling_min_capacity = 0
       autoscaling_max_capacity = 3
     }
 
     production = {
-      instance_type            = "db.t3.micro"
+      instance_type            = "db.t3.medium"
       port                     = 5432
       autoscaling_min_capacity = 1
       autoscaling_max_capacity = 3

--- a/core/locals.tf
+++ b/core/locals.tf
@@ -17,6 +17,9 @@ locals {
   # The health check path of the Application
   health_check_path = "/health"
 
+  # The IP addresses allowed to connect to the bastion host
+  bastion_allowed_ip_connections = []
+
   # The ECS configuration for the current environment
   current_ecs_config = local.ecs_config[var.environment]
 

--- a/core/main.tf
+++ b/core/main.tf
@@ -8,105 +8,105 @@ terraform {
   }
 }
 
-# module "vpc" {
-#   source = "../modules/vpc"
-# }
+module "vpc" {
+  source = "../modules/vpc"
+}
 
-# module "s3" {
-#   source = "../modules/s3"
-# }
+module "s3" {
+  source = "../modules/s3"
+}
 
-# module "security_group" {
-#   source = "../modules/security_group"
+module "security_group" {
+  source = "../modules/security_group"
 
-#   vpc_id                        = module.vpc.vpc_id
-#   app_port                      = local.app_port
-#   rds_port                      = local.current_rds_config.port
-#   elasticache_port              = local.current_elasticache_config.port
-#   private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
-#   bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
-# }
+  vpc_id                        = module.vpc.vpc_id
+  app_port                      = local.app_port
+  rds_port                      = local.current_rds_config.port
+  elasticache_port              = local.current_elasticache_config.port
+  private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
+  bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
+}
 
-# module "alb" {
-#   source = "../modules/alb"
+module "alb" {
+  source = "../modules/alb"
 
-#   vpc_id             = module.vpc.vpc_id
-#   app_port           = local.app_port
-#   subnet_ids         = module.vpc.public_subnet_ids
-#   security_group_ids = module.security_group.alb_security_group_ids
-#   health_check_path  = local.health_check_path
-# }
+  vpc_id             = module.vpc.vpc_id
+  app_port           = local.app_port
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = module.security_group.alb_security_group_ids
+  health_check_path  = local.health_check_path
+}
 
-# module "cloudwatch" {
-#   source = "../modules/cloudwatch"
+module "cloudwatch" {
+  source = "../modules/cloudwatch"
 
-#   kms_key_id = module.secrets_manager.secret_key_arn
-# }
+  kms_key_id = module.secrets_manager.secret_key_arn
+}
 
-# module "secrets_manager" {
-#   source = "../modules/secrets_manager"
+module "secrets_manager" {
+  source = "../modules/secrets_manager"
 
-#   secrets = {
-#     database_url    = module.rds.db_url
-#     redis_url       = module.elasticache.redis_primary_endpoint
-#     secret_key_base = var.secret_key_base
-#   }
-# }
+  secrets = {
+    database_url    = module.rds.db_url
+    redis_url       = module.elasticache.redis_primary_endpoint
+    secret_key_base = var.secret_key_base
+  }
+}
 
-# module "ecs" {
-#   source = "../modules/ecs"
+module "ecs" {
+  source = "../modules/ecs"
 
-#   region                             = local.region
-#   app_port                           = local.app_port
-#   ecr_repo_name                      = local.ecr_repo_name
-#   health_check_path                  = local.health_check_path
-#   subnets                            = module.vpc.private_subnet_ids
-#   security_groups                    = module.security_group.ecs_security_group_ids
-#   alb_target_group_arn               = module.alb.alb_target_group_arn
-#   aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
-#   deployment_maximum_percent         = local.current_ecs_config.deployment_maximum_percent
-#   deployment_minimum_healthy_percent = local.current_ecs_config.deployment_minimum_healthy_percent
-#   web_container_cpu                  = local.current_ecs_config.web_container_cpu
-#   web_container_memory               = local.current_ecs_config.web_container_memory
-#   task_desired_count                 = local.current_ecs_config.task_desired_count
-#   max_capacity                       = local.current_ecs_config.max_capacity
-#   max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
+  region                             = local.region
+  app_port                           = local.app_port
+  ecr_repo_name                      = local.ecr_repo_name
+  health_check_path                  = local.health_check_path
+  subnets                            = module.vpc.private_subnet_ids
+  security_groups                    = module.security_group.ecs_security_group_ids
+  alb_target_group_arn               = module.alb.alb_target_group_arn
+  aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
+  deployment_maximum_percent         = local.current_ecs_config.deployment_maximum_percent
+  deployment_minimum_healthy_percent = local.current_ecs_config.deployment_minimum_healthy_percent
+  web_container_cpu                  = local.current_ecs_config.web_container_cpu
+  web_container_memory               = local.current_ecs_config.web_container_memory
+  task_desired_count                 = local.current_ecs_config.task_desired_count
+  max_capacity                       = local.current_ecs_config.max_capacity
+  max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
 
-#   environment_variables = local.current_environment_variables
-#   secrets_variables     = module.secrets_manager.secrets_variables
-#   secret_arns           = module.secrets_manager.secret_arns
-# }
+  environment_variables = local.current_environment_variables
+  secrets_variables     = module.secrets_manager.secrets_variables
+  secret_arns           = module.secrets_manager.secret_arns
+}
 
-# module "rds" {
-#   source = "../modules/rds"
+module "rds" {
+  source = "../modules/rds"
 
-#   vpc_security_group_ids = module.security_group.rds_security_group_ids
-#   vpc_id                 = module.vpc.vpc_id
-#   subnet_ids             = module.vpc.private_subnet_ids
+  vpc_security_group_ids = module.security_group.rds_security_group_ids
+  vpc_id                 = module.vpc.vpc_id
+  subnet_ids             = module.vpc.private_subnet_ids
 
-#   database_name = var.environment
-#   username      = var.rds_username
-#   password      = var.rds_password
+  database_name = var.environment
+  username      = var.rds_username
+  password      = var.rds_password
 
-#   instance_type            = local.current_rds_config.instance_type
-#   port                     = local.current_rds_config.port
-#   autoscaling_min_capacity = local.current_rds_config.autoscaling_min_capacity
-#   autoscaling_max_capacity = local.current_rds_config.autoscaling_max_capacity
-# }
+  instance_type            = local.current_rds_config.instance_type
+  port                     = local.current_rds_config.port
+  autoscaling_min_capacity = local.current_rds_config.autoscaling_min_capacity
+  autoscaling_max_capacity = local.current_rds_config.autoscaling_max_capacity
+}
 
-# module "elasticache" {
-#   source = "../modules/elasticache"
+module "elasticache" {
+  source = "../modules/elasticache"
 
-#   node_type          = local.current_elasticache_config.node_type
-#   port               = local.current_elasticache_config.port
-#   subnet_ids         = module.vpc.private_subnet_ids
-#   security_group_ids = module.security_group.elasticache_security_group_ids
-#   auth_token         = var.redis_auth_token
-#   kms_key_id         = module.secrets_manager.secret_key_arn
-# }
+  node_type          = local.current_elasticache_config.node_type
+  port               = local.current_elasticache_config.port
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = module.security_group.elasticache_security_group_ids
+  auth_token         = var.redis_auth_token
+  kms_key_id         = module.secrets_manager.secret_key_arn
+}
 
-# module "bastion" {
-#   source = "../modules/bastion"
+module "bastion" {
+  source = "../modules/bastion"
 
-#   instance_security_group_ids = module.security_group.bastion_security_group_ids
-# }
+  instance_security_group_ids = module.security_group.bastion_security_group_ids
+}

--- a/core/main.tf
+++ b/core/main.tf
@@ -8,105 +8,105 @@ terraform {
   }
 }
 
-module "vpc" {
-  source = "../modules/vpc"
-}
+# module "vpc" {
+#   source = "../modules/vpc"
+# }
 
-module "s3" {
-  source = "../modules/s3"
-}
+# module "s3" {
+#   source = "../modules/s3"
+# }
 
-module "security_group" {
-  source = "../modules/security_group"
+# module "security_group" {
+#   source = "../modules/security_group"
 
-  vpc_id                        = module.vpc.vpc_id
-  app_port                      = local.app_port
-  rds_port                      = local.current_rds_config.port
-  elasticache_port              = local.current_elasticache_config.port
-  private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
-  bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
-}
+#   vpc_id                        = module.vpc.vpc_id
+#   app_port                      = local.app_port
+#   rds_port                      = local.current_rds_config.port
+#   elasticache_port              = local.current_elasticache_config.port
+#   private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
+#   bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
+# }
 
-module "alb" {
-  source = "../modules/alb"
+# module "alb" {
+#   source = "../modules/alb"
 
-  vpc_id             = module.vpc.vpc_id
-  app_port           = local.app_port
-  subnet_ids         = module.vpc.public_subnet_ids
-  security_group_ids = module.security_group.alb_security_group_ids
-  health_check_path  = local.health_check_path
-}
+#   vpc_id             = module.vpc.vpc_id
+#   app_port           = local.app_port
+#   subnet_ids         = module.vpc.public_subnet_ids
+#   security_group_ids = module.security_group.alb_security_group_ids
+#   health_check_path  = local.health_check_path
+# }
 
-module "cloudwatch" {
-  source = "../modules/cloudwatch"
+# module "cloudwatch" {
+#   source = "../modules/cloudwatch"
 
-  kms_key_id = module.secrets_manager.secret_key_arn
-}
+#   kms_key_id = module.secrets_manager.secret_key_arn
+# }
 
-module "secrets_manager" {
-  source = "../modules/secrets_manager"
+# module "secrets_manager" {
+#   source = "../modules/secrets_manager"
 
-  secrets = {
-    database_url    = module.rds.db_url
-    redis_url       = module.elasticache.redis_primary_endpoint
-    secret_key_base = var.secret_key_base
-  }
-}
+#   secrets = {
+#     database_url    = module.rds.db_url
+#     redis_url       = module.elasticache.redis_primary_endpoint
+#     secret_key_base = var.secret_key_base
+#   }
+# }
 
-module "ecs" {
-  source = "../modules/ecs"
+# module "ecs" {
+#   source = "../modules/ecs"
 
-  region                             = local.region
-  app_port                           = local.app_port
-  ecr_repo_name                      = local.ecr_repo_name
-  health_check_path                  = local.health_check_path
-  subnets                            = module.vpc.private_subnet_ids
-  security_groups                    = module.security_group.ecs_security_group_ids
-  alb_target_group_arn               = module.alb.alb_target_group_arn
-  aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
-  deployment_maximum_percent         = local.current_ecs_config.deployment_maximum_percent
-  deployment_minimum_healthy_percent = local.current_ecs_config.deployment_minimum_healthy_percent
-  web_container_cpu                  = local.current_ecs_config.web_container_cpu
-  web_container_memory               = local.current_ecs_config.web_container_memory
-  task_desired_count                 = local.current_ecs_config.task_desired_count
-  max_capacity                       = local.current_ecs_config.max_capacity
-  max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
+#   region                             = local.region
+#   app_port                           = local.app_port
+#   ecr_repo_name                      = local.ecr_repo_name
+#   health_check_path                  = local.health_check_path
+#   subnets                            = module.vpc.private_subnet_ids
+#   security_groups                    = module.security_group.ecs_security_group_ids
+#   alb_target_group_arn               = module.alb.alb_target_group_arn
+#   aws_cloudwatch_log_group_name      = module.cloudwatch.aws_cloudwatch_log_group_name
+#   deployment_maximum_percent         = local.current_ecs_config.deployment_maximum_percent
+#   deployment_minimum_healthy_percent = local.current_ecs_config.deployment_minimum_healthy_percent
+#   web_container_cpu                  = local.current_ecs_config.web_container_cpu
+#   web_container_memory               = local.current_ecs_config.web_container_memory
+#   task_desired_count                 = local.current_ecs_config.task_desired_count
+#   max_capacity                       = local.current_ecs_config.max_capacity
+#   max_cpu_threshold                  = local.current_ecs_config.max_cpu_threshold
 
-  environment_variables = local.current_environment_variables
-  secrets_variables     = module.secrets_manager.secrets_variables
-  secret_arns           = module.secrets_manager.secret_arns
-}
+#   environment_variables = local.current_environment_variables
+#   secrets_variables     = module.secrets_manager.secrets_variables
+#   secret_arns           = module.secrets_manager.secret_arns
+# }
 
-module "rds" {
-  source = "../modules/rds"
+# module "rds" {
+#   source = "../modules/rds"
 
-  vpc_security_group_ids = module.security_group.rds_security_group_ids
-  vpc_id                 = module.vpc.vpc_id
-  subnet_ids             = module.vpc.private_subnet_ids
+#   vpc_security_group_ids = module.security_group.rds_security_group_ids
+#   vpc_id                 = module.vpc.vpc_id
+#   subnet_ids             = module.vpc.private_subnet_ids
 
-  database_name = var.environment
-  username      = var.rds_username
-  password      = var.rds_password
+#   database_name = var.environment
+#   username      = var.rds_username
+#   password      = var.rds_password
 
-  instance_type            = local.current_rds_config.instance_type
-  port                     = local.current_rds_config.port
-  autoscaling_min_capacity = local.current_rds_config.autoscaling_min_capacity
-  autoscaling_max_capacity = local.current_rds_config.autoscaling_max_capacity
-}
+#   instance_type            = local.current_rds_config.instance_type
+#   port                     = local.current_rds_config.port
+#   autoscaling_min_capacity = local.current_rds_config.autoscaling_min_capacity
+#   autoscaling_max_capacity = local.current_rds_config.autoscaling_max_capacity
+# }
 
-module "elasticache" {
-  source = "../modules/elasticache"
+# module "elasticache" {
+#   source = "../modules/elasticache"
 
-  node_type          = local.current_elasticache_config.node_type
-  port               = local.current_elasticache_config.port
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = module.security_group.elasticache_security_group_ids
-  auth_token         = var.redis_auth_token
-  kms_key_id         = module.secrets_manager.secret_key_arn
-}
+#   node_type          = local.current_elasticache_config.node_type
+#   port               = local.current_elasticache_config.port
+#   subnet_ids         = module.vpc.private_subnet_ids
+#   security_group_ids = module.security_group.elasticache_security_group_ids
+#   auth_token         = var.redis_auth_token
+#   kms_key_id         = module.secrets_manager.secret_key_arn
+# }
 
-module "bastion" {
-  source = "../modules/bastion"
+# module "bastion" {
+#   source = "../modules/bastion"
 
-  instance_security_group_ids = module.security_group.bastion_security_group_ids
-}
+#   instance_security_group_ids = module.security_group.bastion_security_group_ids
+# }

--- a/core/main.tf
+++ b/core/main.tf
@@ -108,6 +108,5 @@ module "elasticache" {
 module "bastion" {
   source = "../modules/bastion"
 
-  subnet_ids                  = module.vpc.public_subnet_ids
   instance_security_group_ids = module.security_group.bastion_security_group_ids
 }

--- a/core/main.tf
+++ b/core/main.tf
@@ -19,12 +19,12 @@ module "s3" {
 module "security_group" {
   source = "../modules/security_group"
 
-  vpc_id                        = module.vpc.vpc_id
-  app_port                      = local.app_port
-  rds_port                      = local.current_rds_config.port
-  elasticache_port              = local.current_elasticache_config.port
-  private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
-  bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
+  vpc_id                         = module.vpc.vpc_id
+  app_port                       = local.app_port
+  rds_port                       = local.current_rds_config.port
+  elasticache_port               = local.current_elasticache_config.port
+  private_subnets_cidr_blocks    = module.vpc.private_subnets_cidr_blocks
+  bastion_allowed_ip_connections = local.bastion_allowed_ip_connections
 }
 
 module "alb" {

--- a/core/main.tf
+++ b/core/main.tf
@@ -19,11 +19,12 @@ module "s3" {
 module "security_group" {
   source = "../modules/security_group"
 
-  vpc_id                      = module.vpc.vpc_id
-  app_port                    = local.app_port
-  rds_port                    = local.current_rds_config.port
-  elasticache_port            = local.current_elasticache_config.port
-  private_subnets_cidr_blocks = module.vpc.private_subnets_cidr_blocks
+  vpc_id                        = module.vpc.vpc_id
+  app_port                      = local.app_port
+  rds_port                      = local.current_rds_config.port
+  elasticache_port              = local.current_elasticache_config.port
+  private_subnets_cidr_blocks   = module.vpc.private_subnets_cidr_blocks
+  bastion_allowed_ip_connection = var.bastion_allowed_ip_connection
 }
 
 module "alb" {
@@ -102,4 +103,11 @@ module "elasticache" {
   security_group_ids = module.security_group.elasticache_security_group_ids
   auth_token         = var.redis_auth_token
   kms_key_id         = module.secrets_manager.secret_key_arn
+}
+
+module "bastion" {
+  source = "../modules/bastion"
+
+  subnet_ids                  = module.vpc.public_subnet_ids
+  instance_security_group_ids = module.security_group.bastion_security_group_ids
 }

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -26,3 +26,8 @@ variable "redis_auth_token" {
   description = "The auth token for the Redis cluster"
   type        = string
 }
+
+variable "bastion_allowed_ip_connection" {
+  description = "IP that can be connected to Bastion instance"
+  type        = string
+}

--- a/core/variables.tf
+++ b/core/variables.tf
@@ -26,8 +26,3 @@ variable "redis_auth_token" {
   description = "The auth token for the Redis cluster"
   type        = string
 }
-
-variable "bastion_allowed_ip_connection" {
-  description = "IP that can be connected to Bastion instance"
-  type        = string
-}

--- a/modules/bastion/locals.tf
+++ b/modules/bastion/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  namespace = "devops-ic-bastion"
+
+  # The AMI image ID
+  image_id = "ami-08569b978cc4dfa10"
+
+  # The instance type
+  instance_type = "t3.nano"
+
+  # The desired number of the instance
+  instance_desired_count = 1
+
+  # The minimum number of the instance
+  min_instance_count = 1
+
+  # The maximum number of the instance
+  max_instance_count = 1
+}

--- a/modules/bastion/locals.tf
+++ b/modules/bastion/locals.tf
@@ -6,13 +6,4 @@ locals {
 
   # The instance type
   instance_type = "t3.nano"
-
-  # The desired number of the instance
-  instance_desired_count = 1
-
-  # The minimum number of the instance
-  min_instance_count = 1
-
-  # The maximum number of the instance
-  max_instance_count = 1
 }

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -1,0 +1,36 @@
+# tfsec:ignore:aws-ec2-no-public-ip
+resource "aws_launch_configuration" "bastion_instance" {
+  name_prefix                 = local.namespace
+  key_name                    = local.namespace
+  image_id                    = local.image_id
+  instance_type               = local.instance_type
+  security_groups             = var.instance_security_group_ids
+  associate_public_ip_address = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    encrypted = true
+  }
+}
+
+resource "aws_autoscaling_group" "bastion_instance" {
+  launch_configuration = aws_launch_configuration.bastion_instance.name
+  name                 = local.namespace
+  min_size             = local.min_instance_count
+  max_size             = local.max_instance_count
+  desired_capacity     = local.instance_desired_count
+  vpc_zone_identifier  = var.subnet_ids
+
+  tag {
+    key                 = "Name"
+    value               = local.namespace
+    propagate_at_launch = true
+  }
+}

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -19,18 +19,3 @@ resource "aws_launch_configuration" "bastion_instance" {
     encrypted = true
   }
 }
-
-resource "aws_autoscaling_group" "bastion_instance" {
-  launch_configuration = aws_launch_configuration.bastion_instance.name
-  name                 = local.namespace
-  min_size             = local.min_instance_count
-  max_size             = local.max_instance_count
-  desired_capacity     = local.instance_desired_count
-  vpc_zone_identifier  = var.subnet_ids
-
-  tag {
-    key                 = "Name"
-    value               = local.namespace
-    propagate_at_launch = true
-  }
-}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,9 @@
+variable "subnet_ids" {
+  description = "The public subnet IDs for the instance"
+  type        = list(string)
+}
+
+variable "instance_security_group_ids" {
+  description = "The security group IDs for the instance"
+  type        = list(string)
+}

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,8 +1,3 @@
-variable "subnet_ids" {
-  description = "The public subnet IDs for the instance"
-  type        = list(string)
-}
-
 variable "instance_security_group_ids" {
   description = "The security group IDs for the instance"
   type        = list(string)

--- a/modules/ecs/locals.tf
+++ b/modules/ecs/locals.tf
@@ -8,7 +8,10 @@ locals {
   environment_variables = toset([
     { name = "AWS_REGION", value = var.region },
     { name = "HEALTH_CHECK_PATH", value = var.health_check_path },
-    { name = "APP_PORT", value = var.app_port }
+    { name = "APP_PORT", value = var.app_port },
+    { name = "AVAILABLE_LOCALES", value = "en" },
+    { name = "DEFAULT_LOCALE", value = "en" },
+    { name = "FALLBACK_LOCALES", value = "en" }
   ])
 
   container_vars = {

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -3,8 +3,7 @@ module "rds" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "8.5.0"
 
-  name                   = local.namespace
-  create_db_subnet_group = true
+  name = local.namespace
 
   engine         = local.engine
   engine_version = local.engine_version
@@ -13,6 +12,7 @@ module "rds" {
   vpc_id                 = var.vpc_id
   subnets                = var.subnet_ids
   vpc_security_group_ids = var.vpc_security_group_ids
+  create_db_subnet_group = true
 
   instance_class = var.instance_type
   instances = {

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -3,7 +3,8 @@ module "rds" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "8.5.0"
 
-  name = local.namespace
+  name                   = local.namespace
+  create_db_subnet_group = true
 
   engine         = local.engine
   engine_version = local.engine_version

--- a/modules/secrets_manager/main.tf
+++ b/modules/secrets_manager/main.tf
@@ -37,3 +37,10 @@ resource "aws_secretsmanager_secret" "service_secrets" {
     Name = "${local.namespace}-secrets-manager"
   }
 }
+
+resource "aws_secretsmanager_secret_version" "service_secrets" {
+  for_each = var.secrets
+
+  secret_id     = aws_secretsmanager_secret.service_secrets[lower(each.key)].id
+  secret_string = each.value
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -128,12 +128,14 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_security_group_rule" "bastion_ingress_ssh" {
+  for_each = var.bastion_allowed_ip_connections
+
   type              = "ingress"
   protocol          = "tcp"
   from_port         = 22
   to_port           = 22
   security_group_id = aws_security_group.bastion.id
-  cidr_blocks       = ["${var.bastion_allowed_ip_connection}/32"]
+  cidr_blocks       = ["${each.value}/32"]
   description       = "Allowed IP connection"
 }
 

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -137,42 +137,42 @@ resource "aws_security_group_rule" "bastion_ingress_ssh" {
   description       = "Allowed IP connection"
 }
 
-# resource "aws_security_group_rule" "elasticache_ingress_bastion" {
-#   type                     = "ingress"
-#   security_group_id        = aws_security_group.elasticache.id
-#   from_port                = var.elasticache_port
-#   to_port                  = var.elasticache_port
-#   protocol                 = "tcp"
-#   source_security_group_id = aws_security_group.bastion.id
-#   description              = "From bastion to ElastiCache"
-# }
+resource "aws_security_group_rule" "elasticache_ingress_bastion" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.elasticache.id
+  from_port                = var.elasticache_port
+  to_port                  = var.elasticache_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "From bastion to ElastiCache"
+}
 
-# resource "aws_security_group_rule" "bastion_egress_elasticache" {
-#   type                     = "egress"
-#   security_group_id        = aws_security_group.bastion.id
-#   from_port                = var.elasticache_port
-#   to_port                  = var.elasticache_port
-#   protocol                 = "tcp"
-#   source_security_group_id = aws_security_group.elasticache.id
-#   description              = "From ElastiCache to bastion"
-# }
+resource "aws_security_group_rule" "bastion_egress_elasticache" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.bastion.id
+  from_port                = var.elasticache_port
+  to_port                  = var.elasticache_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.elasticache.id
+  description              = "From ElastiCache to bastion"
+}
 
-# resource "aws_security_group_rule" "rds_ingress_bastion" {
-#   type                     = "ingress"
-#   security_group_id        = aws_security_group.rds.id
-#   from_port                = var.rds_port
-#   to_port                  = var.rds_port
-#   protocol                 = "tcp"
-#   source_security_group_id = aws_security_group.bastion.id
-#   description              = "From bastion to RDS"
-# }
+resource "aws_security_group_rule" "rds_ingress_bastion" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.rds.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  description              = "From bastion to RDS"
+}
 
-# resource "aws_security_group_rule" "bastion_egress_rds" {
-#   type                     = "egress"
-#   security_group_id        = aws_security_group.bastion.id
-#   from_port                = var.rds_port
-#   to_port                  = var.rds_port
-#   protocol                 = "tcp"
-#   source_security_group_id = aws_security_group.rds.id
-#   description              = "From RDS to bastion"
-# }
+resource "aws_security_group_rule" "bastion_egress_rds" {
+  type                     = "egress"
+  security_group_id        = aws_security_group.bastion.id
+  from_port                = var.rds_port
+  to_port                  = var.rds_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.rds.id
+  description              = "From RDS to bastion"
+}

--- a/modules/security_group/main.tf
+++ b/modules/security_group/main.tf
@@ -115,3 +115,64 @@ resource "aws_security_group_rule" "elasticache_ingress_app_fargate" {
   source_security_group_id = aws_security_group.ecs_fargate.id
   description              = "From app to cache"
 }
+
+resource "aws_security_group" "bastion" {
+  #checkov:skip=CKV2_AWS_5: This security group will be used by a bastion host
+  name        = "${local.namespace}-bastion"
+  description = "Bastion Security Group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "${local.namespace}-bastion"
+  }
+}
+
+resource "aws_security_group_rule" "bastion_ingress_ssh" {
+  type              = "ingress"
+  protocol          = "tcp"
+  from_port         = 22
+  to_port           = 22
+  security_group_id = aws_security_group.bastion.id
+  cidr_blocks       = ["${var.bastion_allowed_ip_connection}/32"]
+  description       = "Allowed IP connection"
+}
+
+# resource "aws_security_group_rule" "elasticache_ingress_bastion" {
+#   type                     = "ingress"
+#   security_group_id        = aws_security_group.elasticache.id
+#   from_port                = var.elasticache_port
+#   to_port                  = var.elasticache_port
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.bastion.id
+#   description              = "From bastion to ElastiCache"
+# }
+
+# resource "aws_security_group_rule" "bastion_egress_elasticache" {
+#   type                     = "egress"
+#   security_group_id        = aws_security_group.bastion.id
+#   from_port                = var.elasticache_port
+#   to_port                  = var.elasticache_port
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.elasticache.id
+#   description              = "From ElastiCache to bastion"
+# }
+
+# resource "aws_security_group_rule" "rds_ingress_bastion" {
+#   type                     = "ingress"
+#   security_group_id        = aws_security_group.rds.id
+#   from_port                = var.rds_port
+#   to_port                  = var.rds_port
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.bastion.id
+#   description              = "From bastion to RDS"
+# }
+
+# resource "aws_security_group_rule" "bastion_egress_rds" {
+#   type                     = "egress"
+#   security_group_id        = aws_security_group.bastion.id
+#   from_port                = var.rds_port
+#   to_port                  = var.rds_port
+#   protocol                 = "tcp"
+#   source_security_group_id = aws_security_group.rds.id
+#   description              = "From RDS to bastion"
+# }

--- a/modules/security_group/outputs.tf
+++ b/modules/security_group/outputs.tf
@@ -17,3 +17,8 @@ output "elasticache_security_group_ids" {
   description = "Security group IDs for Elasticache"
   value       = [aws_security_group.elasticache.id]
 }
+
+output "bastion_security_group_ids" {
+  description = "Security group IDs for Bastion"
+  value       = [aws_security_group.bastion.id]
+}

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -18,8 +18,12 @@ variable "rds_port" {
   type        = number
 }
 
-
 variable "elasticache_port" {
   description = "The cache node port"
   type        = number
+}
+
+variable "bastion_allowed_ip_connection" {
+  description = "IP that can be connected to Bastion instance"
+  type        = string
 }

--- a/modules/security_group/variables.tf
+++ b/modules/security_group/variables.tf
@@ -23,7 +23,7 @@ variable "elasticache_port" {
   type        = number
 }
 
-variable "bastion_allowed_ip_connection" {
+variable "bastion_allowed_ip_connections" {
   description = "IP that can be connected to Bastion instance"
-  type        = string
+  type        = set(string)
 }


### PR DESCRIPTION
- Close #17

## What happened 👀

Establishing a Bastion server is crucial to creating a secure and centralized access point for connecting to our data storage services such as RDS and Elasticache.
- [x] Assign the security group from SSH (port 22) `to the EC2 Bastion host`
- [x] Assign the security group from EC2 Bastion host `to RDS`
- [x] Assign the security group from EC2 Bastion host `to ElastiCache`

## Insight 📝

Disabled the wrong check that we've already faced before with other resources

- `CKV2_AWS_5`: This security group will be used by EC2 but it still raises a warning

> [!NOTE]  
>  [1] Also modified the RDS module to create the `db_subnet_group` if there's not any existing resource. 
>  [2] Add the missing `aws_secretsmanager_secret_version` that leads to the reason why there's no initial value for each secret
>  [3] Add the missing `environment variables` when trying to deploy the web application


## Proof Of Work 📹
| Modules will be added                                                                                                         |
|-------------------------------------------------------------------------------------------------------------------------------|
| ![image](https://github.com/sanG-github/nimble-devops-ic-infrastructure/assets/63148598/7537b546-90e3-4b9a-9040-3e0dcd0bc996) |

